### PR TITLE
Fix route param format mismatch

### DIFF
--- a/src/utils/apiSpecHelpers.ts
+++ b/src/utils/apiSpecHelpers.ts
@@ -1,22 +1,29 @@
 import fs from 'fs';
-import path from 'path';
+import nodePath from 'path';
 import YAML from 'yaml';
 
+/** Convert path string from OpenAPI style to Express style
+ * @example "/users/{userid}" => "/users/:userid"
+ */
+function convertParamStyle(path: string) {
+  return path.replace(/\{.*?\}/g, (param) => `:${param.slice(1, -1)}`);
+}
+
 export function getOpenApiData(apiDataPath: string) {
-  const file = fs.readFileSync(path.join(__dirname, apiDataPath), 'utf-8');
+  const file = fs.readFileSync(nodePath.join(__dirname, apiDataPath), 'utf-8');
   return YAML.parse(file);
 }
 
 /** Strip 'parameters' property so path object only contains methods */
-export function getMethodsFromPath(apiPath: any) {
-  const { parameters, ...pathData } = apiPath;
+export function getMethodsFromPath(path: any) {
+  const { parameters, ...pathData } = path;
   return pathData;
 }
 
 /** Returns the paths object where each path just has its methods, no parameters */
-export function stripParametersFromPathsObject(paths: any) {
+export function getCleanPathsObject(paths: any) {
   const mappedEntries = Object
     .entries(paths)
-    .map(([pathName, pathData]) => ([pathName, getMethodsFromPath(pathData)]));
+    .map(([pathName, pathData]) => ([convertParamStyle(pathName), getMethodsFromPath(pathData)]));
   return Object.fromEntries(mappedEntries);
 }

--- a/src/utils/routeBuilder.ts
+++ b/src/utils/routeBuilder.ts
@@ -1,5 +1,5 @@
 import { RequestHandler, Router } from 'express';
-import { getOpenApiData, stripParametersFromPathsObject } from './apiSpecHelpers';
+import { getCleanPathsObject, getOpenApiData } from './apiSpecHelpers';
 import { wrapController } from './controllerWrapper';
 import { Method } from './typeHelpers';
 
@@ -52,6 +52,6 @@ export function getRouterFromRouteData<T extends Controller>(
 
 export function getOpenApiRouter(apiDataPath: string, controller: Controller) {
   const data = getOpenApiData(apiDataPath);
-  const paths = stripParametersFromPathsObject(data.paths) as unknown;
+  const paths = getCleanPathsObject(data.paths) as unknown;
   return getRouterFromRouteData(paths as RouteData<typeof controller>, controller);
 }

--- a/tests/utils/apiSpecHelpers.test.ts
+++ b/tests/utils/apiSpecHelpers.test.ts
@@ -1,57 +1,109 @@
-import { getMethodsFromPath, stripParametersFromPathsObject } from '../../src/utils/apiSpecHelpers';
+import { getCleanPathsObject, getMethodsFromPath } from '../../src/utils/apiSpecHelpers';
 
-describe('apiSpecLoaders', () => {
-  describe('getMethodsFromPath', () => {
-    test(
-      'getMethodsFromPath should preserve return the same object without "parameters" property',
-      () => {
-        const before = {
-          parameters: {
-            param1: 'abc',
-            param2: 123,
-          },
+describe('getMethodsFromPath', () => {
+  test(
+    'getMethodsFromPath should preserve return the same object without "parameters" property',
+    () => {
+      const before = {
+        parameters: {
+          param1: 'abc',
+          param2: 123,
+        },
+        get: { operationId: 'getTest' },
+        post: { operationId: 'postTest' },
+      };
+      const after = {
+        get: { operationId: 'getTest' },
+        post: { operationId: 'postTest' },
+      };
+
+      expect(getMethodsFromPath(before)).toEqual(after);
+    },
+  );
+});
+
+describe('getCleanPathsObject', () => {
+  test(
+    'should return the same object but with every path cleaned',
+    () => {
+      const before = {
+        '/path1': {
+          parameters: { param1: 'abc' },
           get: { operationId: 'getTest' },
           post: { operationId: 'postTest' },
-        };
-        const after = {
+        },
+        '/path2': {
+          parameters: { param1: '123' },
+          get: { operationId: 'getPath2Test' },
+          post: { operationId: 'postPath2Test' },
+        },
+      };
+      const after = {
+        '/path1': {
           get: { operationId: 'getTest' },
           post: { operationId: 'postTest' },
-        };
+        },
+        '/path2': {
+          get: { operationId: 'getPath2Test' },
+          post: { operationId: 'postPath2Test' },
+        },
+      };
 
-        expect(getMethodsFromPath(before)).toEqual(after);
+      expect(getCleanPathsObject(before)).toEqual(after);
+    },
+  );
+
+  test('should transform route params to match Express format (param ends path)', () => {
+    const beforePath = '/users/{userid}';
+    const afterPath = '/users/:userid';
+
+    const before = {
+      [beforePath]: {
+        get: { operationId: 'getTest' },
       },
-    );
+    };
+    const after = {
+      [afterPath]: {
+        get: { operationId: 'getTest' },
+      },
+    };
+
+    expect(getCleanPathsObject(before)).toEqual(after);
   });
 
-  describe('stripParametersFromPathsObject', () => {
-    test(
-      'stripParametersFromPathsObject should return the same object but with every path cleaned',
-      () => {
-        const before = {
-          '/path1': {
-            parameters: { param1: 'abc' },
-            get: { operationId: 'getTest' },
-            post: { operationId: 'postTest' },
-          },
-          '/path2': {
-            parameters: { param1: '123' },
-            get: { operationId: 'getPath2Test' },
-            post: { operationId: 'postPath2Test' },
-          },
-        };
-        const after = {
-          '/path1': {
-            get: { operationId: 'getTest' },
-            post: { operationId: 'postTest' },
-          },
-          '/path2': {
-            get: { operationId: 'getPath2Test' },
-            post: { operationId: 'postPath2Test' },
-          },
-        };
+  test('should transform route params to match Express format (param does not end path)', () => {
+    const beforePath = '/users/{userid}/blah';
+    const afterPath = '/users/:userid/blah';
 
-        expect(stripParametersFromPathsObject(before)).toEqual(after);
+    const before = {
+      [beforePath]: {
+        get: { operationId: 'getTest' },
       },
-    );
+    };
+    const after = {
+      [afterPath]: {
+        get: { operationId: 'getTest' },
+      },
+    };
+
+    expect(getCleanPathsObject(before)).toEqual(after);
+  });
+
+  test('should transform route params to match Express format (multiple params)', () => {
+    const beforePath = '/users/{userid}/blah/{friendshipid}';
+    const afterPath = '/users/:userid/blah/:friendshipid';
+
+    const before = {
+      [beforePath]: {
+        get: { operationId: 'getTest' },
+      },
+    };
+    const after = {
+      [afterPath]: {
+        get: { operationId: 'getTest' },
+      },
+    };
+
+    expect(getCleanPathsObject(before)).toEqual(after);
   });
 });


### PR DESCRIPTION
OpenAPI uses {param} while Express uses :param

Adds a helper to ensure these are swapped out correctly.